### PR TITLE
Copyedit the top-level "design" documents.

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -7,7 +7,7 @@ date = "2001-01-02"
 
 [Read more about the rationale for `gb`](/rationale).
 
-## Project Based
+## Project-Based
 
 `gb` operates on the concept of a project. A `gb` project is a workspace for all the Go code that is required to build your project. 
 

--- a/content/rationale.md
+++ b/content/rationale.md
@@ -5,29 +5,29 @@ date = "2001-01-01"
 +++
 ## Reproducible Builds
 
-Go does not have reproducible builds because the import statement, which drives `go get`, does not contain sufficient information to identify which revision of a package it should fetch.
+Go does not have reproducible builds because the `import statement`&mdash;which drives `go get`&mdash;does not contain sufficient information to identify which revision of a package it should fetch.
 
 ## Import Path Imprecision
 
-From the point of view of the language and its specification, the argument to the `import` statement, the import path, is opaque. Its interpretation is dependant on the tool processing the file. `go get` interprets the import path as a URL to fetch source code. The compiler interprets the import path as a location on disk where it will find a matching compiled package.
+From the point of view of the language and its specification, the argument to the `import` statement&mdash;the import path&mdash;is opaque. Its interpretation is dependant on the tool processing the file. `go get` interprets the import path as a URL to fetch source code. The compiler interprets the import path as a location on disk where it will find a matching compiled package.
 
 Note: The import path of a package is _not_ the package's name (although convention dictates that they match). The former is dictated by the path on disk where the source files are found. The latter comes from the `package` declaration at the top of the `.go` file. 
 
-Peter Bourgon notes that Go packages exist in both space and time. Space is the namespacing convention of using your companies domain or GitHub URL in the import path of a package.
+Peter Bourgon notes that Go packages exist in both space and time. Space is the namespacing convention of using your company's domain or GitHub URL in the import path of a package.
 
-As for the time component, the import statement is mute; it does not contain any information which could identify one copy of a package's source from another.
+As for the time component, the `import` statement is mute; it does not contain any information which could identify one copy of a package's source from another.
 
 It is important to note that Go packages do not have versions, at least not in the way that many consider libraries in other languages to have versions. The source of a Go package _may_ be tracked by a revision control system, and that revision control system may use a revision number or hash to identify a copy of the source at a point in time, but this is not a version number.
 
-The primary reason why Go projects cannot be reproducibly built is two independent invocations of `go get` may fetch revisions of that code. Additionally, if the source code of a package stored in a remote repository changes in an incompatible way, there is no way for code that consumes that import path to indicate that it does not want to blindly fetch the latest revision of the code.
+The primary reason why Go projects cannot be reproducibly built is that two independent invocations of `go get` may fetch revisions of that code. Additionally, if the source code of a package stored in a remote repository changes in an incompatible way, there is no way for code that consumes that import path to indicate that it does not want to blindly fetch the latest revision of the code.
 
 ## Vendoring
 
 The solution to this problem is to ensure that your Go project includes in its repository all the code it depends on. This is colloquially known as _vendoring_. 
 
-Vendoring code isolates the project from later changes in the repositories of code that it depends on. It also isolates it from political, organisational, or financial events which may affect the availability of those remote repositories.
+Vendoring code isolates the project from later changes in the repositories of code that it depends on. It also isolates it from political, organisational, or financial events that may affect the availability of those remote repositories.
 
-However, the `go` tool does not make vendoring easy. A repository fetched with `go get` will always be checked out in a matching directory on the local computer and so any other code included in that repository will be checked out relative to that location, _not_ in the location that the compiler requires.
+However, the `go` tool does not make vendoring easy. A repository fetched with `go get` will always be checked out in a matching directory on the local computer, and so any other code included in that repository will be checked out relative to that location, _not_ in the location that the compiler requires.
 
 ## Import Rewriting
 
@@ -35,9 +35,9 @@ To work around this limitation, the recommended approach is to rewrite the sourc
 
 ## Why A New Build Tool?
 
-It is clear that the reason Go developers do not have reproducible builds today stems from `go get`. Import rewriting and placing tags or version numbers in the package's import paths are work arounds layered on top of the limitations of `go get`.
+It is clear that the reason Go developers do not have reproducible builds today stems from `go get`. Import rewriting and placing tags or version numbers in the package's import paths are workarounds layered on top of the limitations of `go get`.
 
-`gb` is a new build tool that does not wrap the `go` tool, nor does it use `$GOPATH`. `gb` replace the `go` tool's workspace metaphor with a project based approach which natively allows vendoring without the import rewriting work arounds mandated by `go get` and a `$GOPATH` workspace.
+`gb` is a new build tool that does not wrap the `go` tool, nor does it use `$GOPATH`. `gb` replace the `go` tool's workspace metaphor with a project-based approach&mdash;one that natively allows vendoring without the import rewriting work arounds mandated by `go get` and a `$GOPATH` workspace.
 
 ## Read More
 

--- a/content/theory.md
+++ b/content/theory.md
@@ -7,25 +7,25 @@ This article outlines the general theory of compiling Go code, then describes th
 
 ## Theory
 
-Go is a compiled language, and thus needs a compiler tool chain (compiler, assembler, linker, etc) to convert source code into runable machine code. Go's compilation model differs from traditional compiled languages in the C family (C, C++, Objective-C, etc) by not using header files. Instead of header files, the Go compilers work with packages, which are both the output of and the input to compilation.
+Go is a compiled language, and thus needs a compiler tool chain (compiler, assembler, linker, etc.) to convert source code into runable machine code. Go's compilation model differs from traditional compiled languages in the C family (C, C++, Objective-C, etc.) by not using header files. Instead of header files, the Go compilers work with packages, which are both the output of and the input to compilation.
 
 `gb` and the `go` tool are two implementations of programs that analyse Go source code and invoke the Go compiler in a manner that ensures that the dependencies of a package are always compiled before the package itself.
 
 ### Import paths
 
-When the go compiler encounters a an `import` statement, it interprets the argument to that statement as a path on disk, relative to a list of paths passed to the compiler with the `-I` flag. Importantly the arguments to `-I` are not where the source of Go code is stored, but rather the compiled versions. To give an example, if the compiler encounters this statement:
+When the go compiler encounters a an `import` statement, it interprets the argument to that statement as a path on disk, relative to a list of paths passed to the compiler with the `-I` flag. Importantly the arguments to `-I` are not where the source of Go code is stored, but rather the compiled versions. To give an example, if the compiler encounters the statement
 
      import "github.com/pkg/term"
 
-It will search its list of include paths (and finally `$GOROOT/pkg`), for a file called `github.com/pkg/term.a`, and will use the information inside it when compiling. The `-I` argument to the compiler are ordered, with `$GOROOT/pkg` coming first, then any `-I` paths. The Go compiler knows nothing about `$GOPATH`.
+it will search its list of include paths (and finally `$GOROOT/pkg`) for a file called `github.com/pkg/term.a`, and will use the information inside it when compiling. The `-I` argument to the compiler are ordered, with `$GOROOT/pkg` coming first, then any `-I` paths. The Go compiler knows nothing about `$GOPATH`.
 
 ### Incremental compilation
 
-Because the dependencies of a package must be compiled before the package itself, incremental compilation, by storing and reusing the results of previous compilation runs falls out naturally from the operation of tools like `gb` and `go`.
+Because the dependencies of a package must be compiled before the package itself, incremental compilation&mdash;by storing and reusing the results of previous compilation runs&mdash;falls out naturally from the operation of tools like `gb` and `go`.
 
 ### Build tags and conditional compilation
 
-The Go compiler is executed once per package, [conditional compilation](http://dave.cheney.net/2013/10/12/how-to-use-conditional-compilation-with-the-go-build-tool) via `// +build` tags and file name suffixes is achieved by modifying the set of files passed to the Go compiler. This can complicate incremental compilation.
+The Go compiler is executed once per package; [conditional compilation](http://dave.cheney.net/2013/10/12/how-to-use-conditional-compilation-with-the-go-build-tool) via `// +build` tags and file name suffixes is achieved by modifying the set of files passed to the Go compiler. This can complicate incremental compilation.
 
 ## Operation
 
@@ -33,32 +33,32 @@ As an implementation of a tool that drives Go compilation, `gb` works as follows
 
 ### Argument parsing
 
-With the exception of plugins, all `gb` commands take the following form
+With the exception of plugins, all `gb` commands take the following form:
 
      gb $COMMAND [flags] arguments...
 
-Once `gb` has determined the [project root](https://godoc.org/github.com/constabulary/gb/cmd#FindProjectroot) and constructed a [build context](https://godoc.org/github.com/constabulary/gb#Context) it parses the arguments supplied into import paths. These import paths are considered the roots for the operation of commands. For example
+Once `gb` has determined the [project root](https://godoc.org/github.com/constabulary/gb/cmd#FindProjectroot) and constructed a [build context](https://godoc.org/github.com/constabulary/gb#Context) it parses the arguments supplied into import paths. These import paths are considered the roots for the operation of commands. For example, the command
 
      gb build .../sftp
 
-Will invoke the build command for each package who's import path ends in `sftp`.
+will invoke the _build_ command for each package whose import path ends in `sftp`.
 
 Arguments can be file paths, import paths, aliases (like `all`), and globs of file or import paths. The specific form of the arguments are described in the [usage document](/docs/usage/).
 
 ### Package resolution
 
-Using the build context each import path is [resolved to a package](https://godoc.org/github.com/constabulary/gb#Context.ResolvePackage). Package resolution involves locating the source that matches an import path, this may be in `$PROJECT/src`, or `$PROJECT/vendor/src` (noting that the former shadows the latter), and inspecting the source with respect to the constraints applicable to the build context. ie filtering out files which don't match the current operating system or architecture. Package resolution is a recursive process as one package may import another. 
+Using the build context, each import path is [resolved to a package](https://godoc.org/github.com/constabulary/gb#Context.ResolvePackage). Package resolution involves locating the source that matches an import path&mdash;this may be in `$PROJECT/src`, or `$PROJECT/vendor/src` (noting that the former shadows the latter)&mdash;and inspecting the source with respect to the constraints applicable to the build context (i.e. filtering out files which don't match the current operating system or architecture). Package resolution is a recursive process as one package may import another. 
 
 The build context holds references to every package resolved through it, so resolving multiple import paths is efficient.
 
 ### Incremental compilation
 
-`gb` tries to transparently reuse the results of previous compilations where ever possible, we call this incremental compilation. As discussed above, Go packages contain symbols from the packages they depend on, so if the source that a package depends on has changed, its compiled version must be recompiled. During package resolution the staleness of a package is computed recursively.
+`gb` tries to transparently reuse the results of previous compilations wherever possible; we call this incremental compilation. As discussed above, Go packages contain symbols from the packages they depend on, so if the source that a package depends on has changed, its compiled version must be recompiled. During package resolution the staleness of a package is computed recursively.
 
 ### Compilation and linking
 
-With package resolution complete, the build context now holds references to all the packages, and their relevant source files. Starting from the import paths, the roots of the graph, `gb` will compile each package which is considered to be stale. This is a recursive process whereby a package's dependencies are compiled before any package that depends on them. If the package is not stale, compilation is skipped and instead a reference to the compiled package stored in `$PROJECT/pkg` is used.
+With package resolution complete, the build context now holds references both to all the packages and their relevant source files. Starting from the import paths&mdash;the roots of the graph&mdash;`gb` will compile each package that is considered to be stale. This is a recursive process whereby a package's dependencies are compiled before any package that depends on them. If the package is not stale, compilation is skipped and instead a reference to the compiled package stored in `$PROJECT/pkg` is used.
 
-Once a package is compiled, a copy of it is stored in `$PROJECT/pkg` for reuse. Some packages are not cached, specifically the results of compiling a `package main` command, or the results of compiling packages for use by `gb test`.
+Once a package is compiled, a copy of it is stored in `$PROJECT/pkg` for reuse. Some packages are not cached&mdash;specifically the results of compiling a `package main` command, or the results of compiling packages for use by `gb test`.
 
 If any of the import paths are commands, `gb` will invoke the linker and place the final program in `$PROJECT/bin`.


### PR DESCRIPTION
Replace commas with semicolons or em dashes as appropriate, among other adjustments to punctuation and spelling corrections.
