### PR TITLE
Fix markdown formatting for CLI flag

### DIFF
--- a/content/docs/usage.md
+++ b/content/docs/usage.md
@@ -44,4 +44,4 @@ The following flags are supported by `gb`. Note that these are flags to subcomma
 - `-q` - decreases verbosity, effectively raising the output level to ERROR. In a successful build, no output will be displayed.
 - `-f` - ignore cached packages if present, new packages built will overwrite any cached packages. This effectively disables incremental compilation.
 - `-F` - do not cache packages, cached packages will still be used for incremental compilation, `-f -F` is advised to disable the package caching system.
-- '-ldflags' - pass flags to linker, mainly used to set build information at link time. eg, `-ldflags "-X main.gitRevision aabbccdd"`
+- `-ldflags` - pass flags to linker, mainly used to set build information at link time. eg, `-ldflags "-X main.gitRevision aabbccdd"`


### PR DESCRIPTION
The last flag name should be set in a `code` block like the others as well.
